### PR TITLE
Add User model with authentication support

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class User extends Authenticatable
+{
+    /** @use HasFactory<\Database\Factories\UserFactory> */
+    use HasFactory, Notifiable;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ */
+class UserFactory extends Factory
+{
+    protected static ?string $password;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
+            'email_verified_at' => now(),
+            'password' => static::$password ??= Hash::make('password'),
+            'remember_token' => Str::random(10),
+        ];
+    }
+
+    public function unverified(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'email_verified_at' => null,
+        ]);
+    }
+}

--- a/database/migrations/2025_12_15_043947_create_users_table.php
+++ b/database/migrations/2025_12_15_043947_create_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+describe('User', function () {
+    it('can be created with factory', function () {
+        $user = User::factory()->create();
+
+        expect($user)->toBeInstanceOf(User::class);
+        expect($user->name)->toBeString();
+        expect($user->email)->toBeString();
+    });
+
+    it('hides password and remember_token in serialization', function () {
+        $user = User::factory()->create();
+        $array = $user->toArray();
+
+        expect($array)->not->toHaveKey('password');
+        expect($array)->not->toHaveKey('remember_token');
+    });
+
+    it('casts email_verified_at to datetime', function () {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        expect($user->email_verified_at)->toBeInstanceOf(\Illuminate\Support\Carbon::class);
+    });
+
+    it('hashes password automatically', function () {
+        $user = User::factory()->create([
+            'password' => 'plain-text-password',
+        ]);
+
+        expect($user->password)->not->toBe('plain-text-password');
+        expect(password_verify('plain-text-password', $user->password))->toBeTrue();
+    });
+
+    it('can create unverified user', function () {
+        $user = User::factory()->unverified()->create();
+
+        expect($user->email_verified_at)->toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- Adds User model extending Authenticatable for API auth support
- Includes factory with unverified() state
- Migration creates users table with standard auth fields
- 100% test coverage

## Test Plan
- [x] User can be created with factory
- [x] Password and remember_token hidden in serialization
- [x] email_verified_at casted to datetime
- [x] Password automatically hashed
- [x] unverified() state works